### PR TITLE
build: use ubuntu-latest for update workflow

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   update:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout tap


### PR DESCRIPTION
I thought we might need to update the `sed` calls but I think they are good (we could test this workflow manually, but it might also push changes?)

Closes #1 